### PR TITLE
Add backend server test

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ json5
 Flask-CORS
 langchain_openai
 python-dotenv
+pytest
+langchain-community

--- a/tests/test_backend_server.py
+++ b/tests/test_backend_server.py
@@ -4,7 +4,7 @@ import json
 import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-os.environ.setdefault("TAVILY_API_KEY", "test")
+os.environ.setdefault("TAVILY_API_KEY", "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")
 os.environ.setdefault("OPENAI_API_KEY", "test")
 from backend.server import backend_app
 

--- a/tests/test_backend_server.py
+++ b/tests/test_backend_server.py
@@ -3,9 +3,10 @@ import sys
 import json
 import pytest
 
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-os.environ.setdefault("TAVILY_API_KEY", "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")
-os.environ.setdefault("OPENAI_API_KEY", "test")
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+# Use provided API keys if set; otherwise fall back to placeholders for testing
+os.environ.setdefault("TAVILY_API_KEY", os.environ.get("TAVILY_API_KEY", "tvly-dev-REDACTED"))
+os.environ.setdefault("OPENAI_API_KEY", os.environ.get("OPENAI_API_KEY", "sk-proj-REDACTED"))
 from backend.server import backend_app
 
 @pytest.fixture

--- a/tests/test_backend_server.py
+++ b/tests/test_backend_server.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import json
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+os.environ.setdefault("TAVILY_API_KEY", "test")
+os.environ.setdefault("OPENAI_API_KEY", "test")
+from backend.server import backend_app
+
+@pytest.fixture
+
+def client():
+    with backend_app.test_client() as client:
+        yield client
+
+def test_index_route(client):
+    response = client.get('/')
+    assert response.status_code == 200
+    assert response.get_json() == {"status": "Running"}


### PR DESCRIPTION
## Summary
- add pytest and langchain-community to requirements
- add a test for backend server index route

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685134eccdf48320aa60f92bb251c70e